### PR TITLE
Fix the case when FieldType.String comes as OptionFieldValue 

### DIFF
--- a/src/main/scala/com/nulabinc/backlog/j2b/issue/writer/convert/IssueFieldWrites.scala
+++ b/src/main/scala/com/nulabinc/backlog/j2b/issue/writer/convert/IssueFieldWrites.scala
@@ -93,10 +93,14 @@ class IssueFieldWrites @Inject() (customFieldDefinitions: Seq[Field])
                 )
             }
           case FieldType.String =>
-            toTextCustomField(
-              field,
-              issueField.value.asInstanceOf[StringFieldValue]
-            )
+            var stringFieldValue: StringFieldValue = null
+            issueField.value match {
+              case optionFieldValue: OptionFieldValue =>
+                stringFieldValue = StringFieldValue(optionFieldValue.value)
+              case _ =>
+                stringFieldValue = issueField.value.asInstanceOf[StringFieldValue]
+            }
+            toTextCustomField(field, stringFieldValue)
           case FieldType.Unknown =>
             toTextCustomField(
               field,


### PR DESCRIPTION
Without this fix, custom field that comes as an OptionFieldValue rather than StringFieldValue, produces this fatal error:

```2022/07/14 05:13:50.130 228847 [scala-execution-context-global-26] ERROR c.n.b.j.i.w.c.IssueFieldWrites - class com.nulabinc.backlog.j2b.jira.domain.export.OptionFieldValue cannot be cast to class com.nulabinc.backlog.j2b.jira.domain.export.StringFieldValue (com.nulabinc.backlog.j2b.jira.domain.export.OptionFieldValue and com.nulabinc.backlog.j2b.jira.domain.export.StringFieldValue are in unnamed module of loader 'app') Value: OptionFieldValue(IssueFieldOption(10001,StringFieldValue(To Do)))
2022/07/14 05:13:50.133 228850 [scala-execution-context-global-26] ERROR com.nulabinc.backlog.j2b.App$ - class com.nulabinc.backlog.j2b.jira.domain.export.OptionFieldValue cannot be cast to class com.nulabinc.backlog.j2b.jira.domain.export.StringFieldValue (com.nulabinc.backlog.j2b.jira.domain.export.OptionFieldValue and com.nulabinc.backlog.j2b.jira.domain.export.StringFieldValue are in unnamed module of loader 'app')
java.lang.ClassCastException: class com.nulabinc.backlog.j2b.jira.domain.export.OptionFieldValue cannot be cast to class com.nulabinc.backlog.j2b.jira.domain.export.StringFieldValue (com.nulabinc.backlog.j2b.jira.domain.export.OptionFieldValue and com.nulabinc.backlog.j2b.jira.domain.export.StringFieldValue are in unnamed module of loader 'app')
	at com.nulabinc.backlog.j2b.issue.writer.convert.IssueFieldWrites.$anonfun$writes$2(IssueFieldWrites.scala:98)
	at scala.Option.map(Option.scala:242)
	at com.nulabinc.backlog.j2b.issue.writer.convert.IssueFieldWrites.writes(IssueFieldWrites.scala:19)```

