### PR TITLE
Export - fix users mixing up in jiraUsers.json

### DIFF
--- a/src/main/scala/com/nulabinc/backlog/j2b/exporter/Exporter.scala
+++ b/src/main/scala/com/nulabinc/backlog/j2b/exporter/Exporter.scala
@@ -321,7 +321,7 @@ class Exporter @Inject() (
               ExistingMappingUser(
                 user.accountId,
                 user.displayName,
-                issue.creator.emailAddress
+                user.emailAddress
               )
             )
           )


### PR DESCRIPTION
Without this fix, the users are mixed up in the `jiraUsers.json` file produced during the `export` phase:

![image](https://user-images.githubusercontent.com/5769929/186560913-b6b2459d-44d3-40e6-92f2-e496664b98d9.png)
